### PR TITLE
Add OwnerReference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/goccy/go-yaml v1.11.3
+	github.com/google/go-cmp v0.6.0
 	github.com/mattn/go-tty v0.0.5
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3


### PR DESCRIPTION
It maybe be useful that the created job will be associated with original CronJob.
For example, when original CronJob is deleted, the created job is also deleted.

This may affect the origin CronJob? I don't know...
But, I think manual run is same behavior.