### PR TITLE
feat: consider `KUBECONFIG` environment as a default kubeconfig

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,8 +38,17 @@ func main() {
 
 func run() int {
 	var kubeconfig *string
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	// default kubeconfig path is loaded in the following priority:
+	// 1. load environment variable KUBECONFIG exists
+	// 2. load $HOME/.kube/config
+	var defaultKubeConfig string
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		defaultKubeConfig = env
+	} else if home := homedir.HomeDir(); home != "" {
+		defaultKubeConfig = filepath.Join(home, ".kube", "config")
+	}
+	if defaultKubeConfig != "" {
+		kubeconfig = flag.String("kubeconfig", defaultKubeConfig, "(optional) absolute path to the kubeconfig file")
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}


### PR DESCRIPTION
## What
consider the `KUBECONFIG` environment variable as a default config, then see the config under home directory

https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable

## Why
Some context-switching tools like https://github.com/sbstp/kubie, create a temporary  `KUBECONFIG` and overwrite its environment variable in the shell.
This pr aims to work this CLI on such a shell without specifying the temporary config.