### PR TITLE
feat:Refactor createJob function to separate responsibilities

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,8 +237,8 @@ func createJobWithFileName(filename *string, job *batchv1.Job) error {
 		jobFilename = *filename
 	}
 
-	editor := &InteractiveJobEditor{
-		Filename: jobFilename,
+	editor := &interactiveJobEditor{
+		filename: jobFilename,
 	}
 
 	if err := editor.EditJob(job); err != nil {
@@ -301,15 +301,17 @@ func confirmByUser(tty *tty.TTY) (bool, error) {
 	}
 }
 
-type JobEditor interface {
-	EditJob(job *batchv1.Job) error
-}
-type InteractiveJobEditor struct {
-	Filename string
+// TODO: feature add patchJobEditor
+//
+//	type jobEditor interface {
+//		EditJob(job *batchv1.Job) error
+//	}
+type interactiveJobEditor struct {
+	filename string
 }
 
-func (e *InteractiveJobEditor) EditJob(job *batchv1.Job) error {
-	f, err := os.Create(e.Filename)
+func (e *interactiveJobEditor) EditJob(job *batchv1.Job) error {
+	f, err := os.Create(e.filename)
 	if err != nil {
 		return err
 	}
@@ -319,7 +321,7 @@ func (e *InteractiveJobEditor) EditJob(job *batchv1.Job) error {
 		return err
 	}
 
-	return editFile(e.Filename)
+	return editFile(e.filename)
 }
 
 func writeJobToFile(f *os.File, job *batchv1.Job) error {


### PR DESCRIPTION
# Refactoring createJob function

This PR refactors the `createJob` function to separate responsibilities and introduce a strategy pattern for job editing.

## Changes in this PR

### 1. Separate responsibilities in createJob
- Split the original `createJob` function into multiple smaller functions with single responsibilities:
  - `writeJobToFile`: Writes Job YAML to a file
  - `editFile`: Opens the file in the editor
  - `confirmJobCreation`: Gets user confirmation
  - `applyJob`: Applies the job to Kubernetes

### 2. Introduce JobEditor interface
- Add `JobEditor` interface to abstract the job editing process
- Implement `InteractiveJobEditor` as the default editor (using $EDITOR)

## Design

Here's the design diagram of the refactored code:
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/b8408cbd-af21-4c05-b364-917853012998" />

## Future Work

In future PRs, I plan to:

1. Implement a `PatchJobEditor` that can modify YAML using patch specifications
2. Add a `--patch` flag to specify path and value for patching (format: `--patch={path:"spec.template.spec.containers[0].image",value:"nginx:latest"}`)
3. Further separate business logic from UI components
4. Add comprehensive tests for new components

This refactoring lays the groundwork for these upcoming features by introducing a clean separation of concerns and a flexible strategy pattern for job editing.

## Testing

I've tested this refactoring by:
- Building and running the command with existing functionality
- Ensuring all tests pass with `go test ./...`
- Manually testing the job creation flow