### PR TITLE
feat:Add patch-file option

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,11 +130,13 @@ Options:
 	}
 
 	var editor jobEditor
+	skipConfirm := false
 	if patchFile != nil && *patchFile != "" {
 		editor = &patchJobEditor{
 			filename:  jobFilename,
 			patchFile: *patchFile,
 		}
+		skipConfirm = true
 	} else {
 		editor = &interactiveJobEditor{
 			filename: jobFilename,
@@ -146,13 +148,15 @@ Options:
 		return exitStatusErr
 	}
 
-	confirmed, err := confirmByUser()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: %v\n", cmdName, err)
-	}
-	if !confirmed {
-		fmt.Println("canceled")
-		return exitStatusOK
+	if !skipConfirm {
+		confirmed, err := confirmByUser()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", cmdName, err)
+		}
+		if !confirmed {
+			fmt.Println("canceled")
+			return exitStatusOK
+		}
 	}
 
 	if err := applyJob(jobFilename); err != nil {

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func run() int {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 	filename = flag.String("f", "", "(optional) filename to save Job resource")
-	patchFile = flag.String("patch-file", "", "(optional) JSON file with patch information")
+	patchFile = flag.String("patch-file", "", "(optional) JSON file with patch information. Patch file format :Refer to https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/")
 	flag.Usage = func() {
 		fmt.Printf(`%[1]s - create custom job from cronjob template
 
@@ -78,10 +78,6 @@ Examples:
     
     # Apply patch from JSON or YAML file without opening an editor
     %[1]s --patch-file=/path/to/patch.json namespace name 
-    
-	# Patch file format :
-	# Refer to https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/
-
 
 Options:
 `, cmdName)
@@ -435,7 +431,6 @@ func (e *patchJobEditor) EditJob(job *batchv1.Job) error {
 
 func applyJob(filename string) error {
 	cmd := exec.Command("kubectl", "apply", "-f", filename)
-	cmd.Stdin = nil
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func run() int {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 	filename = flag.String("f", "", "(optional) filename to save Job resource")
-	patchFile = flag.String("patch-file", "", "(optional) JSON file with patch information. Patch file format :Refer to https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/")
+	patchFile = flag.String("patch-file", "", "(optional) JSON file with patch information. The file format is specified in the URL below. https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/")
 	flag.Usage = func() {
 		fmt.Printf(`%[1]s - create custom job from cronjob template
 

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ Examples:
     %[1]s --patch-file=/path/to/patch.json namespace name 
     
 	# Patch file format :
-    # Refer to https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/
+	# Refer to https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/
 
 
 Options:

--- a/main.go
+++ b/main.go
@@ -237,8 +237,8 @@ func createJobWithFileName(filename *string, job *batchv1.Job) error {
 		jobFilename = *filename
 	}
 
-	editor := &InteractiveJobEditor{
-		Filename: jobFilename,
+	editor := &interactiveJobEditor{
+		filename: jobFilename,
 	}
 
 	if err := editor.EditJob(job); err != nil {
@@ -301,15 +301,17 @@ func confirmByUser(tty *tty.TTY) (bool, error) {
 	}
 }
 
-type JobEditor interface {
-	EditJob(job *batchv1.Job) error
-}
-type InteractiveJobEditor struct {
-	Filename string
+// TODO: feature add patchJobEditor
+//
+//	type jobEditor interface {
+//		EditJob(job *batchv1.Job) error
+//	}
+type interactiveJobEditor struct {
+	filename string
 }
 
-func (e *InteractiveJobEditor) EditJob(job *batchv1.Job) error {
-	f, err := os.Create(e.Filename)
+func (e *interactiveJobEditor) EditJob(job *batchv1.Job) error {
+	f, err := os.Create(e.filename)
 	if err != nil {
 		return err
 	}
@@ -319,7 +321,7 @@ func (e *InteractiveJobEditor) EditJob(job *batchv1.Job) error {
 		return err
 	}
 
-	return editFile(e.Filename)
+	return editFile(e.filename)
 }
 
 func writeJobToFile(f *os.File, job *batchv1.Job) error {

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ Options:
 	}
 
 	var editor jobEditor
+	// If patchFile is specified, skip interactive editing and apply the patch
 	skipConfirm := false
 	if patchFile != nil && *patchFile != "" {
 		editor = &patchJobEditor{

--- a/patch_test.go
+++ b/patch_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestLoadPatchFromFile(t *testing.T) {
+
+	tempDir, err := os.MkdirTemp("", "patch-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	patchContent := `{
+		"path": "spec.template.spec.containers[0].image",
+		"value": "new-image:latest"
+	}`
+	patchFilePath := filepath.Join(tempDir, "test-patch.json")
+	if err := os.WriteFile(patchFilePath, []byte(patchContent), 0644); err != nil {
+		t.Fatalf("failed to write patch file: %v", err)
+	}
+
+	patch, err := loadPatchFromFile(patchFilePath)
+	if err != nil {
+		t.Fatalf("loadPatchFromFile failed: %v", err)
+	}
+
+	expectedPath := "spec.template.spec.containers[0].image"
+	expectedValue := "new-image:latest"
+
+	if patch.Path != expectedPath {
+		t.Errorf("expected path %q, got %q", expectedPath, patch.Path)
+	}
+
+	valueStr, ok := patch.Value.(string)
+	if !ok {
+		t.Fatalf("expected value to be string, got %T", patch.Value)
+	}
+
+	if valueStr != expectedValue {
+		t.Errorf("expected value %q, got %q", expectedValue, valueStr)
+	}
+}
+
+func TestApplyPatchToYaml(t *testing.T) {
+
+	jobYaml := []byte(`apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: test-container
+        image: original-image:v1
+        command: ["echo", "hello"]
+`)
+
+	tests := map[string]struct {
+		patch          patchFile
+		expectedResult string
+		expectError    bool
+	}{
+		"simple string value": {
+			patch: patchFile{
+				Path:  "spec.template.spec.containers[0].image",
+				Value: "new-image:v2",
+			},
+			expectedResult: "new-image:v2",
+			expectError:    false,
+		},
+		"array value": {
+			patch: patchFile{
+				Path:  "spec.template.spec.containers[0].command",
+				Value: []interface{}{"python", "script.py", "--arg", "value"},
+			},
+			expectedResult: "[python script.py --arg value]",
+			expectError:    false,
+		},
+		"nested object": {
+			patch: patchFile{
+				Path: "spec.template.spec.containers[0].resources",
+				Value: map[string]interface{}{
+					"limits": map[string]interface{}{
+						"cpu":    "100m",
+						"memory": "128Mi",
+					},
+				},
+			},
+			expectedResult: "map[limits:map[cpu:100m memory:128Mi]]",
+			expectError:    false,
+		},
+		"invalid index": {
+			patch: patchFile{
+				Path:  "spec.template.spec.containers[5].image",
+				Value: "should-fail",
+			},
+			expectError: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := applyPatchToYaml(jobYaml, tt.patch)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					t.Errorf(tt.patch.Path)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var jobMap map[string]interface{}
+			if err := yaml.Unmarshal(result, &jobMap); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+
+			segments := strings.Split(tt.patch.Path, ".")
+			currentMap := jobMap
+
+			for i, segment := range segments {
+
+				if i == len(segments)-1 {
+					var actualValue interface{}
+
+					if strings.Contains(segment, "[") && strings.Contains(segment, "]") {
+						indexStart := strings.Index(segment, "[")
+						indexEnd := strings.Index(segment, "]")
+						arrayName := segment[:indexStart]
+						indexStr := segment[indexStart+1 : indexEnd]
+						index, _ := strconv.Atoi(indexStr)
+
+						array, ok := currentMap[arrayName].([]interface{})
+						if !ok {
+							t.Fatalf("expected array at %s", arrayName)
+						}
+
+						element := array[index].(map[string]interface{})
+						fieldName := segment[indexEnd+1:]
+						if fieldName != "" && strings.HasPrefix(fieldName, ".") {
+							fieldName = fieldName[1:]
+							actualValue = element[fieldName]
+						} else {
+							actualValue = element
+						}
+					} else {
+						actualValue = currentMap[segment]
+					}
+
+					actualValueStr := fmt.Sprintf("%v", actualValue)
+					if actualValueStr != tt.expectedResult {
+						t.Errorf("expected %q, got %q", tt.expectedResult, actualValueStr)
+					}
+					break
+				}
+
+				if strings.Contains(segment, "[") && strings.Contains(segment, "]") {
+					indexStart := strings.Index(segment, "[")
+					indexEnd := strings.Index(segment, "]")
+					arrayName := segment[:indexStart]
+					indexStr := segment[indexStart+1 : indexEnd]
+					index, _ := strconv.Atoi(indexStr)
+
+					array, ok := currentMap[arrayName].([]interface{})
+					if !ok {
+						t.Fatalf("expected array at %s", arrayName)
+					}
+
+					currentMap = array[index].(map[string]interface{})
+				} else {
+					nextMap, ok := currentMap[segment].(map[string]interface{})
+					if !ok {
+						t.Fatalf("expected map at %s, got %T", segment, currentMap[segment])
+					}
+					currentMap = nextMap
+				}
+			}
+		})
+	}
+}
+
+func TestPatchJobEditor(t *testing.T) {
+
+	tempDir, err := os.MkdirTemp("", "editor-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	job := &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: batchv1.JobSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "test-container",
+							Image:   "original-image:v1",
+							Command: []string{"echo", "hello"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	patchContent := `{
+		"path": "spec.template.spec.containers[0].command",
+		"value": ["python", "script.py", "--flag", "value"]
+	}`
+	patchFilePath := filepath.Join(tempDir, "test-patch.json")
+	if err := os.WriteFile(patchFilePath, []byte(patchContent), 0644); err != nil {
+		t.Fatalf("failed to write patch file: %v", err)
+	}
+
+	outputFilePath := filepath.Join(tempDir, "output.yaml")
+
+	editor := &patchJobEditor{
+		filename:  outputFilePath,
+		patchFile: patchFilePath,
+	}
+
+	if err := editor.EditJob(job); err != nil {
+		t.Fatalf("EditJob failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outputFilePath)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+
+	var jobMap map[string]interface{}
+	if err := yaml.Unmarshal(data, &jobMap); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	spec := jobMap["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	templateSpec := template["spec"].(map[string]interface{})
+	containers := templateSpec["containers"].([]interface{})
+	container := containers[0].(map[string]interface{})
+	command := container["command"].([]interface{})
+
+	expectedCommand := []string{"python", "script.py", "--flag", "value"}
+	if len(command) != len(expectedCommand) {
+		t.Errorf("expected command length %d, got %d", len(expectedCommand), len(command))
+	}
+
+	for i, cmd := range expectedCommand {
+		if i < len(command) && command[i] != cmd {
+			t.Errorf("expected command[%d] to be %q, got %q", i, cmd, command[i])
+		}
+	}
+}

--- a/patch_test.go
+++ b/patch_test.go
@@ -1,211 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 
-func TestLoadPatchFromFile(t *testing.T) {
-
-	tempDir, err := os.MkdirTemp("", "patch-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	patchContent := `{
-		"path": "spec.template.spec.containers[0].image",
-		"value": "new-image:latest"
-	}`
-	patchFilePath := filepath.Join(tempDir, "test-patch.json")
-	if err := os.WriteFile(patchFilePath, []byte(patchContent), 0644); err != nil {
-		t.Fatalf("failed to write patch file: %v", err)
-	}
-
-	patch, err := loadPatchFromFile(patchFilePath)
-	if err != nil {
-		t.Fatalf("loadPatchFromFile failed: %v", err)
-	}
-
-	expectedPath := "spec.template.spec.containers[0].image"
-	expectedValue := "new-image:latest"
-
-	if patch.Path != expectedPath {
-		t.Errorf("expected path %q, got %q", expectedPath, patch.Path)
-	}
-
-	valueStr, ok := patch.Value.(string)
-	if !ok {
-		t.Fatalf("expected value to be string, got %T", patch.Value)
-	}
-
-	if valueStr != expectedValue {
-		t.Errorf("expected value %q, got %q", expectedValue, valueStr)
-	}
-}
-
-func TestApplyPatchToYaml(t *testing.T) {
-
-	jobYaml := []byte(`apiVersion: batch/v1
-kind: Job
-metadata:
-  name: test-job
-spec:
-  template:
-    spec:
-      containers:
-      - name: test-container
-        image: original-image:v1
-        command: ["echo", "hello"]
-`)
-
-	tests := map[string]struct {
-		patch          patchFile
-		expectedResult string
-		expectError    bool
-	}{
-		"simple string value": {
-			patch: patchFile{
-				Path:  "spec.template.spec.containers[0].image",
-				Value: "new-image:v2",
-			},
-			expectedResult: "new-image:v2",
-			expectError:    false,
-		},
-		"array value": {
-			patch: patchFile{
-				Path:  "spec.template.spec.containers[0].command",
-				Value: []interface{}{"python", "script.py", "--arg", "value"},
-			},
-			expectedResult: "[python script.py --arg value]",
-			expectError:    false,
-		},
-		"nested object": {
-			patch: patchFile{
-				Path: "spec.template.spec.containers[0].resources",
-				Value: map[string]interface{}{
-					"limits": map[string]interface{}{
-						"cpu":    "100m",
-						"memory": "128Mi",
-					},
-				},
-			},
-			expectedResult: "map[limits:map[cpu:100m memory:128Mi]]",
-			expectError:    false,
-		},
-		"nonexistent path segment": {
-			patch: patchFile{
-				Path:  "spec.template.spec.containers[0].nonexistent.field",
-				Value: "new-value",
-			},
-			expectedResult: "new-value",
-			expectError:    false,
-		},
-		"invalid index": {
-			patch: patchFile{
-				Path:  "spec.template.spec.containers[5].image",
-				Value: "should-fail",
-			},
-			expectError: true,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			result, err := applyPatchToYaml(jobYaml, tt.patch)
-
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("expected error but got none")
-					t.Errorf(tt.patch.Path)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			var jobMap map[string]interface{}
-			if err := yaml.Unmarshal(result, &jobMap); err != nil {
-				t.Fatalf("failed to unmarshal result: %v", err)
-			}
-
-			segments := strings.Split(tt.patch.Path, ".")
-			currentMap := jobMap
-
-			for i, segment := range segments {
-
-				if i == len(segments)-1 {
-					var actualValue interface{}
-
-					if strings.Contains(segment, "[") && strings.Contains(segment, "]") {
-						indexStart := strings.Index(segment, "[")
-						indexEnd := strings.Index(segment, "]")
-						arrayName := segment[:indexStart]
-						indexStr := segment[indexStart+1 : indexEnd]
-						index, _ := strconv.Atoi(indexStr)
-
-						array, ok := currentMap[arrayName].([]interface{})
-						if !ok {
-							t.Fatalf("expected array at %s", arrayName)
-						}
-
-						element := array[index].(map[string]interface{})
-						fieldName := segment[indexEnd+1:]
-						if fieldName != "" && strings.HasPrefix(fieldName, ".") {
-							fieldName = fieldName[1:]
-							actualValue = element[fieldName]
-						} else {
-							actualValue = element
-						}
-					} else {
-						actualValue = currentMap[segment]
-					}
-
-					actualValueStr := fmt.Sprintf("%v", actualValue)
-					if actualValueStr != tt.expectedResult {
-						t.Errorf("expected %q, got %q", tt.expectedResult, actualValueStr)
-					}
-					break
-				}
-
-				if strings.Contains(segment, "[") && strings.Contains(segment, "]") {
-					indexStart := strings.Index(segment, "[")
-					indexEnd := strings.Index(segment, "]")
-					arrayName := segment[:indexStart]
-					indexStr := segment[indexStart+1 : indexEnd]
-					index, _ := strconv.Atoi(indexStr)
-
-					array, ok := currentMap[arrayName].([]interface{})
-					if !ok {
-						t.Fatalf("expected array at %s", arrayName)
-					}
-
-					currentMap = array[index].(map[string]interface{})
-				} else {
-					nextMap, ok := currentMap[segment].(map[string]interface{})
-					if !ok {
-						t.Fatalf("expected map at %s, got %T", segment, currentMap[segment])
-					}
-					currentMap = nextMap
-				}
-			}
-		})
-	}
-}
-
 func TestPatchJobEditor(t *testing.T) {
-
 	tempDir, err := os.MkdirTemp("", "editor-test")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
@@ -236,51 +43,111 @@ func TestPatchJobEditor(t *testing.T) {
 		},
 	}
 
-	patchContent := `{
-		"path": "spec.template.spec.containers[0].command",
-		"value": ["python", "script.py", "--flag", "value"]
-	}`
-	patchFilePath := filepath.Join(tempDir, "test-patch.json")
-	if err := os.WriteFile(patchFilePath, []byte(patchContent), 0644); err != nil {
-		t.Fatalf("failed to write patch file: %v", err)
+	tests := map[string]struct {
+		patchContent    string
+		expectedImage   string
+		expectedCommand []string
+	}{
+		"JSON patch format": {
+			patchContent: `{
+				"spec": {
+					"template": {
+						"spec": {
+							"containers": [
+								{
+									"name": "test-container",
+									"image": "new-image:v2",
+									"command": ["python", "script.py", "--flag", "value"]
+								}
+							]
+						}
+					}
+				}
+			}`,
+			expectedImage:   "new-image:v2",
+			expectedCommand: []string{"python", "script.py", "--flag", "value"},
+		},
+		"YAML patch format": {
+			patchContent: `
+spec:
+  template:
+    spec:
+      containers:
+        - name: test-container
+          image: yaml-image:latest
+          command:
+            - node
+            - server.js
+            - --port=8080
+`,
+			expectedImage:   "yaml-image:latest",
+			expectedCommand: []string{"node", "server.js", "--port=8080"},
+		},
+		"minimal JSON patch": {
+			patchContent:    `{"spec":{"template":{"spec":{"containers":[{"name":"test-container","image":"minimal-image"}]}}}}`,
+			expectedImage:   "minimal-image",
+			expectedCommand: []string{"echo", "hello"},
+		},
+		"minimal YAML patch": {
+			patchContent: `
+spec:
+  template:
+    spec:
+      containers:
+        - name: test-container
+          image: minimal-yaml-image
+`,
+			expectedImage:   "minimal-yaml-image",
+			expectedCommand: []string{"echo", "hello"},
+		},
 	}
 
-	outputFilePath := filepath.Join(tempDir, "output.yaml")
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			patchFilePath := filepath.Join(tempDir, name+"-patch.yaml")
+			if err := os.WriteFile(patchFilePath, []byte(tt.patchContent), 0644); err != nil {
+				t.Fatalf("failed to write patch file: %v", err)
+			}
 
-	editor := &patchJobEditor{
-		filename:  outputFilePath,
-		patchFile: patchFilePath,
-	}
+			outputFilePath := filepath.Join(tempDir, name+"-output.yaml")
 
-	if err := editor.EditJob(job); err != nil {
-		t.Fatalf("EditJob failed: %v", err)
-	}
+			editor := &patchJobEditor{
+				filename:  outputFilePath,
+				patchFile: patchFilePath,
+			}
 
-	data, err := os.ReadFile(outputFilePath)
-	if err != nil {
-		t.Fatalf("failed to read output file: %v", err)
-	}
+			jobCopy := job.DeepCopy()
+			if err := editor.EditJob(jobCopy); err != nil {
+				t.Fatalf("EditJob failed: %v", err)
+			}
 
-	var jobMap map[string]interface{}
-	if err := yaml.Unmarshal(data, &jobMap); err != nil {
-		t.Fatalf("failed to unmarshal result: %v", err)
-	}
+			data, err := os.ReadFile(outputFilePath)
+			if err != nil {
+				t.Fatalf("failed to read output file: %v", err)
+			}
 
-	spec := jobMap["spec"].(map[string]interface{})
-	template := spec["template"].(map[string]interface{})
-	templateSpec := template["spec"].(map[string]interface{})
-	containers := templateSpec["containers"].([]interface{})
-	container := containers[0].(map[string]interface{})
-	command := container["command"].([]interface{})
+			jsonData, err := yaml.YAMLToJSON(data)
+			if err != nil {
+				t.Fatalf("failed to convert YAML to JSON: %v", err)
+			}
 
-	expectedCommand := []string{"python", "script.py", "--flag", "value"}
-	if len(command) != len(expectedCommand) {
-		t.Errorf("expected command length %d, got %d", len(expectedCommand), len(command))
-	}
+			patchedJob := &batchv1.Job{}
+			if err := yaml.Unmarshal(jsonData, patchedJob); err != nil {
+				t.Fatalf("failed to unmarshal patched job: %v", err)
+			}
 
-	for i, cmd := range expectedCommand {
-		if i < len(command) && command[i] != cmd {
-			t.Errorf("expected command[%d] to be %q, got %q", i, cmd, command[i])
-		}
+			if len(patchedJob.Spec.Template.Spec.Containers) != 1 {
+				t.Fatalf("expected 1 container, got %d", len(patchedJob.Spec.Template.Spec.Containers))
+			}
+
+			container := patchedJob.Spec.Template.Spec.Containers[0]
+			if container.Image != tt.expectedImage {
+				t.Errorf("expected image %q, got %q", tt.expectedImage, container.Image)
+			}
+
+			if diff := cmp.Diff(tt.expectedCommand, container.Command); diff != "" {
+				t.Errorf("unexpected command diff: %s", diff)
+			}
+		})
 	}
 }

--- a/patch_test.go
+++ b/patch_test.go
@@ -102,6 +102,14 @@ spec:
 			expectedResult: "map[limits:map[cpu:100m memory:128Mi]]",
 			expectError:    false,
 		},
+		"nonexistent path segment": {
+			patch: patchFile{
+				Path:  "spec.template.spec.containers[0].nonexistent.field",
+				Value: "new-value",
+			},
+			expectedResult: "new-value",
+			expectError:    false,
+		},
 		"invalid index": {
 			patch: patchFile{
 				Path:  "spec.template.spec.containers[5].image",


### PR DESCRIPTION
## Overview
This PR introduces a new `--patch-file` option that allows users to apply predefined changes to job templates without opening an interactive editor. This is particularly useful for automation scenarios where the tool is being called from scripts or other programs.

## Changes
- Added a new `--patch-file` flag to specify a JSON file containing patch information
- Implemented a `patchJobEditor` type that applies JSON patches to job templates
- Updated help message to include documentation for the new option
- Added comprehensive test coverage for the new functionality

## Example Usage
```bash
# Apply patch from JSON file without opening an editor
kj --patch-file=/path/to/patch.json namespace name 

# Patch file format (JSON):
{
  "path": "spec.template.spec.containers[0].command",
  "value": ["python", "main.py", "--option", "value"]
}
```

## Future Work
This change is part of a broader effort to support non-interactive usage of `kj`. In the future, we plan to:
- Implement a fully non-interactive mode for automation workflows
- Add support for programmatic invocation from languages like Python

## Testing
The changes have been tested with various patch scenarios including:
- Simple string value replacements
- Array value modifications
- Nested object updates
- Adding elements to a new path
- Edge cases with invalid indices

All existing functionality continues to work as expected, with the new patching capability being optional and non-disruptive to current workflows.